### PR TITLE
Stream response body in ASGITransport

### DIFF
--- a/httpx/_transports/asgi.py
+++ b/httpx/_transports/asgi.py
@@ -1,3 +1,4 @@
+import types
 import typing
 
 import sniffio
@@ -33,12 +34,76 @@ def create_event() -> "Event":
         return asyncio.Event()
 
 
+class _AwaitableRunner:
+    def __init__(self, awaitable: typing.Awaitable[typing.Any]):
+        self._generator = awaitable.__await__()
+        self._started = False
+        self._next_item: typing.Any = None
+        self._finished = False
+
+    @types.coroutine
+    def __call__(
+        self, *, until: typing.Optional[typing.Callable[[], bool]] = None
+    ) -> typing.Generator[typing.Any, typing.Any, typing.Any]:
+        while not self._finished and (until is None or not until()):
+            send_value, throw_value = None, None
+            if self._started:
+                try:
+                    send_value = yield self._next_item
+                except BaseException as e:
+                    throw_value = e
+
+            self._started = True
+            try:
+                if throw_value is not None:
+                    self._next_item = self._generator.throw(throw_value)
+                else:
+                    self._next_item = self._generator.send(send_value)
+            except StopIteration as e:
+                self._exception = None
+                self._finished = True
+                return e.value
+            except BaseException:
+                self._generator.close()
+                self._finished = True
+                raise
+
+
 class ASGIResponseStream(AsyncByteStream):
-    def __init__(self, body: typing.List[bytes]) -> None:
+    def __init__(
+        self,
+        body: typing.List[bytes],
+        raise_app_exceptions: bool,
+        response_complete: "Event",
+        app_runner: _AwaitableRunner,
+    ) -> None:
         self._body = body
+        self._raise_app_exceptions = raise_app_exceptions
+        self._response_complete = response_complete
+        self._app_runner = app_runner
 
     async def __aiter__(self) -> typing.AsyncIterator[bytes]:
-        yield b"".join(self._body)
+        try:
+            while bool(self._body) or not self._response_complete.is_set():
+                if self._body:
+                    yield b"".join(self._body)
+                    self._body.clear()
+                await self._app_runner(
+                    until=lambda: bool(self._body) or self._response_complete.is_set()
+                )
+        except Exception:  # noqa: PIE786
+            if self._raise_app_exceptions:
+                raise
+        finally:
+            await self.aclose()
+
+    async def aclose(self) -> None:
+        self._response_complete.set()
+        try:
+            await self._app_runner()
+        except Exception:  # noqa: PIE786
+            if self._raise_app_exceptions:
+                raise
 
 
 class ASGITransport(AsyncBaseTransport):
@@ -145,8 +210,10 @@ class ASGITransport(AsyncBaseTransport):
                 response_headers = message.get("headers", [])
                 response_started = True
 
-            elif message["type"] == "http.response.body":
-                assert not response_complete.is_set()
+            elif (
+                message["type"] == "http.response.body"
+                and not response_complete.is_set()
+            ):
                 body = message.get("body", b"")
                 more_body = message.get("more_body", False)
 
@@ -156,9 +223,11 @@ class ASGITransport(AsyncBaseTransport):
                 if not more_body:
                     response_complete.set()
 
+        app_runner = _AwaitableRunner(self.app(scope, receive, send))
+
         try:
-            await self.app(scope, receive, send)
-        except Exception:  # noqa: PIE-786
+            await app_runner(until=lambda: response_started)
+        except Exception:  # noqa: PIE786
             if self.raise_app_exceptions:
                 raise
 
@@ -168,10 +237,11 @@ class ASGITransport(AsyncBaseTransport):
             if response_headers is None:
                 response_headers = {}
 
-        assert response_complete.is_set()
         assert status_code is not None
         assert response_headers is not None
 
-        stream = ASGIResponseStream(body_parts)
+        stream = ASGIResponseStream(
+            body_parts, self.raise_app_exceptions, response_complete, app_runner
+        )
 
         return Response(status_code, headers=response_headers, stream=stream)

--- a/httpx/_transports/asgi.py
+++ b/httpx/_transports/asgi.py
@@ -16,11 +16,9 @@ if typing.TYPE_CHECKING:  # pragma: no cover
 
 _Message = typing.Dict[str, typing.Any]
 _Receive = typing.Callable[[], typing.Awaitable[_Message]]
-_Send = typing.Callable[
-    [typing.Dict[str, typing.Any]], typing.Coroutine[None, None, None]
-]
+_Send = typing.Callable[[_Message], typing.Awaitable[None]]
 _ASGIApp = typing.Callable[
-    [typing.Dict[str, typing.Any], _Receive, _Send], typing.Coroutine[None, None, None]
+    [typing.Dict[str, typing.Any], _Receive, _Send], typing.Awaitable[None]
 ]
 
 
@@ -123,7 +121,7 @@ class ASGITransport(AsyncBaseTransport):
 
         # ASGI callables.
 
-        async def receive() -> typing.Dict[str, typing.Any]:
+        async def receive() -> _Message:
             nonlocal request_complete
 
             if request_complete:
@@ -137,7 +135,7 @@ class ASGITransport(AsyncBaseTransport):
                 return {"type": "http.request", "body": b"", "more_body": False}
             return {"type": "http.request", "body": body, "more_body": True}
 
-        async def send(message: typing.Dict[str, typing.Any]) -> None:
+        async def send(message: _Message) -> None:
             nonlocal status_code, response_headers, response_started
 
             if message["type"] == "http.response.start":


### PR DESCRIPTION
# Summary

As part of my job, we needed a variant of `ASGITransport` that
supports streaming (as in #2186), and this is my PR to implement that.

Something that I am particularly proud of is that this PR was written without having to spawn a new task, with the consequence that it avoids issues related to task groups and context variables. 

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
